### PR TITLE
Added configuration to support javadoc and test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,50 @@
                     <mainClass>calculator.Main</mainClass>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.2</version>
+                <executions>
+                    <!--configures testing coverage-->
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+
+                    <!--generates report in target/site/jacoco-->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <configuration>
+                    <!--needed to prevent module problem-->
+                    <detectJavaApiLink>false</detectJavaApiLink>
+                </configuration>
+                <executions>
+                    <!-- Exports JavaDocs to regular HTML files -->
+                    <!--javadoc to target/site/apidocs-->
+                    <execution>
+                        <id>javadoc-html</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>javadoc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
JaCoCo report will be generated during the testing and will be stored in target/site/jacoco.

Javadoc will be generated when packaging the application (mvn package) and stored in target/site/apidocs