### PR TITLE
Excluding main from Jacoco coverage.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>calculator/Main.class</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Signed-off-by: Damien Legay <none@none.com>

Coverage is now 91%. Only parts not covered: the prints from Calculator (and I don't think we should test System.out.println), and the default in the switch in Operation.toString(Notation), which should never be triggered (unless someone passes null as a Notation).